### PR TITLE
📖 Docs: Add Linux Mint / Ubuntu / Debian installation notes (PEP 668)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ There's a few other smaller options, see the code.
 - **Responsive design** that works on mobile
 - **Search-friendly** - use Ctrl+F to find anything across all files
 
+## Linux installation notes
+
+Recent versions of Ubuntu (23.04+), Linux Mint (21.2+), and Debian (12+) follow [PEP 668](https://peps.python.org/pep-0668/), which blocks system-wide `pip install` to protect system packages.
+
+To install `rendergit` safely, use a virtual environment:
+
+```bash
+sudo apt install python3.12-venv -y   # install venv support
+git clone https://github.com/karpathy/rendergit
+cd rendergit
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
 ## Contributing
 
 I vibe coded this utility a few months ago but I keep using it very often so I figured I'd just share it. I don't super intend to maintain or support it though.


### PR DESCRIPTION
### Summary
This PR updates the `README.md` to include a note for users on **Ubuntu 23.04+, Linux Mint 21.2+, and Debian 12+**, which follow [PEP 668](https://peps.python.org/pep-0668/).  
These systems prevent system-wide `pip` installs by default, so installation must be done inside a virtual environment.

### Changes
- Added a new section with installation instructions for Linux Mint/Ubuntu/Debian users.
- Included steps to install `python3-venv`, create a virtual environment, and install `rendergit` inside it.